### PR TITLE
URL path prefix config param for installations in sub folders

### DIFF
--- a/application/controllers/IndexController.php
+++ b/application/controllers/IndexController.php
@@ -26,6 +26,7 @@ class BoxyDash_IndexController extends Controller
     protected $default_boxsize = 20;
     protected $default_refresh = 10;
     protected $default_showlegend = true;
+    protected $default_path_prefix = '';
 
     public function indexAction()
     {
@@ -35,6 +36,7 @@ class BoxyDash_IndexController extends Controller
         $this->determine_refresh();
         $this->determine_showlegend();
         $this->determine_boxsize();
+        $this->determine_path_prefix();
         $this->determine_include_softstate();
 
 
@@ -64,7 +66,7 @@ class BoxyDash_IndexController extends Controller
             $this->view->showlegend = (boolean) $this->_getParam("showlegend");
             #Failing that, check to see if it's already in the configuration or use the default legend
         }else{
-            $this->view->showlegend = (boolean)  $this->config->get('settings','show_legend',$this->default_showlegend); 
+            $this->view->showlegend = (boolean)  $this->config->get('settings','show_legend',$this->default_showlegend);
         }
     }
 
@@ -111,6 +113,11 @@ class BoxyDash_IndexController extends Controller
         }
 
 #        $this->view->debug= intval( (bool)$this->view->include_softstate);
+    }
+
+    public function determine_path_prefix()
+    {
+        $this->view->path_prefix = $this->config->get('settings', 'path_prefix', $this->default_path_prefix);
     }
 
 

--- a/application/forms/Config/SettingConfigForm.php
+++ b/application/forms/Config/SettingConfigForm.php
@@ -101,6 +101,15 @@ class SettingConfigForm extends ConfigForm
                 'description'   => $this->translate('Do you want to show the legend?')
             )
         );
+        $this->addElement(
+            'text',
+            'path_prefix',
+            array(
+                'label'         => $this->translate('URL path prefix'),
+                'description'   => $this->translate('Prefix prepended to all links, eg "/icingaweb2". Required in case Icinga Web 2 is installed in a subfolder (eg "http://your-domain.tld/icingaweb2").'),
+                'value'         => '',
+            )
+        );
 
     }
 

--- a/application/views/scripts/index/index.phtml
+++ b/application/views/scripts/index/index.phtml
@@ -49,7 +49,7 @@ foreach ($this->hosts as $host){
         $content= "&#10004;";
         $title.=" (Acknowledged)";
     }?>
-    <a href='/monitoring/host/show?host=<?=$host->{'host_name'}?>' class='boxy_box state <?=$returncode?>' style='width:<?=$size?>px; height:<?=$size?>px; font-size:<?=$size?>px;' title="<?=$title?>"><?=$content?></a>
+    <a href='<?= $this->path_prefix ?>/monitoring/host/show?host=<?=$host->{'host_name'}?>' class='boxy_box state <?=$returncode?>' style='width:<?=$size?>px; height:<?=$size?>px; font-size:<?=$size?>px;' title="<?=$title?>"><?=$content?></a>
 <? } ?>
 
 <br clear="all"/>
@@ -76,7 +76,7 @@ foreach ($this->hosts as $host){
         $title.=" (Host Issue Acknowledged)";
     }
     $title=htmlspecialchars($title."\n ".$service->{'service_output'});?>
-    <a href='/monitoring/service/show?host=<?=$service->{'host_name'}?>&service=<?=$service->{'service_description'}?>' class='boxy_box state <?=$returncode?>' style='width:<?=$size?>px; height:<?=$size?>px; font-size:<?=$size?>px;' title="<?=$title?>"><?=$content?></a>
+    <a href='<?= $this->path_prefix ?>/monitoring/service/show?host=<?=$service->{'host_name'}?>&service=<?=$service->{'service_description'}?>' class='boxy_box state <?=$returncode?>' style='width:<?=$size?>px; height:<?=$size?>px; font-size:<?=$size?>px;' title="<?=$title?>"><?=$content?></a>
 
 <? } ?>
 <br clear=all>


### PR DESCRIPTION
We're using multiple (web) interfaces for Icinga and install each in a sub-folder, eg `http://our-icinga.tld/icingaweb2`. Hence the hard coded links to `/monitoring/service/show?host=foobar` did not work. Thought this might be worth sharing.
