### PR TITLE
Added line to obey roles filter on object level

### DIFF
--- a/application/controllers/IndexController.php
+++ b/application/controllers/IndexController.php
@@ -175,6 +175,7 @@ class BoxyDash_IndexController extends Controller
 
         );
         $query = $this->backend->select()->from('hostStatus', $columns);
+        $this->applyRestriction('monitoring/filter/objects', $query); // follow filter object restrictions
         $query->order('host_name', 'desc');
 
         # This might be very very bad for very very large environments. I just don't know how well it'll perform.
@@ -221,6 +222,7 @@ class BoxyDash_IndexController extends Controller
             'max_check_attempts'    => 'service_max_check_attempts'
         );
         $query = $this->backend->select()->from('serviceStatus', $columns);
+        $this->applyRestriction('monitoring/filter/objects', $query); // follow filter object restrictions
         $query->order('host_name', 'desc');
 
         $this->view->services = $query->getQuery()->fetchAll();


### PR DESCRIPTION
Boxydash will follow the roles.ini definition like:
monitoring/filter/objects = "host_name=_win_"

A user/group with this filter will be limited to see hosts in BoxyDash who match filter _win_
