### PR TITLE
Make Boxydash configuration available

### DIFF
--- a/application/forms/Config/SettingConfigForm.php
+++ b/application/forms/Config/SettingConfigForm.php
@@ -107,7 +107,7 @@ class SettingConfigForm extends ConfigForm
             array(
                 'label'         => $this->translate('URL path prefix'),
                 'description'   => $this->translate('Prefix prepended to all links, eg "/icingaweb2". Required in case Icinga Web 2 is installed in a subfolder (eg "http://your-domain.tld/icingaweb2").'),
-                'value'         => '',
+                'value'         => '/icingaweb2',
             )
         );
 

--- a/configuration.php
+++ b/configuration.php
@@ -11,3 +11,8 @@ $this->menuSection('Boxy Dashboard', array(
     'priority'  => 20
 ));
 
+$this->provideConfigTab('config', array(
+    'title' => $this->translate('Configure boxydash'),
+    'label' => $this->translate('config'),
+    'url' => 'config'
+));

--- a/library/BoxyDash/Grid.php
+++ b/library/BoxyDash/Grid.php
@@ -24,4 +24,4 @@ class Grid extends WebBaseHook
         $this->baseUrl   = rtrim($cfg->get('base_url', $this->baseUrl), '/');
     }
 
-
+}


### PR DESCRIPTION
Please enable configuration tab upstream by merging this pull-request.

When i installed and enabled the boxydash module the menu-point in icingaweb2 only displayed a HTTP 404 because the "path_prefix" was set to empty string. I wasn't configurable, through the web-interface.